### PR TITLE
Feature/min datapoints per update

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -78,6 +78,7 @@ MAX_CREATES_PER_MINUTE = 50
 # suitable complement for the "naive" CACHE_WRITE_STRATEGY.
 #
 # The default value for LOW_CACHE_SIZE is 80% of MAX_CACHE_SIZE.
+# Value for LOW_CACHE_SIZE must be less than 0.95 * MAX_CACHE_SIZE (which is the threshold for applying flow_control if enabled)  
 MIN_DATAPOINTS_PER_UPDATE = 1
 LOW_CACHE_SIZE = inf
 

--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -75,7 +75,7 @@ MAX_CREATES_PER_MINUTE = 50
 # carbon-cache instance getting a share of disk I/O.
 #
 # It helps to avoid a large number of small disk-writes as well, making it a
-# suitable complement for the "naive" CACHE_WRITE_STRATEGY.
+# suitable complement for the "random" CACHE_WRITE_STRATEGY.
 #
 # The default value for LOW_CACHE_SIZE is 80% of MAX_CACHE_SIZE.
 # Value for LOW_CACHE_SIZE must be less than 0.95 * MAX_CACHE_SIZE (which is the threshold for applying flow_control if enabled)  
@@ -141,7 +141,7 @@ LOG_CACHE_HITS = False
 # there are a large number of metrics which receive very frequent updates OR if
 # disk i/o is very slow.
 #
-# naive - Metrics will be flushed from the cache to disk in an unordered
+# random - Metrics will be flushed from the cache to disk in an unordered
 # fashion. This strategy may be desirable in situations where the storage for
 # whisper files is solid state, CPU resources are very limited or deference to
 # the OS's i/o scheduler is expected to compensate for the random write

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -20,12 +20,11 @@ from twisted.internet.protocol import ServerFactory
 from twisted.python.components import Componentized
 from twisted.python.log import ILogObserver
 # Attaching modules to the global state module simplifies import order hassles
-from carbon import state, events, instrumentation, util
+from carbon import state, events, util
 from carbon.exceptions import CarbonConfigException
 from carbon.log import carbonLogObserver
 from carbon.pipeline import Processor, run_pipeline
 state.events = events
-state.instrumentation = instrumentation
 
 
 class CarbonRootService(MultiService):
@@ -38,6 +37,9 @@ class CarbonRootService(MultiService):
 
 
 def createBaseService(config, settings):
+    from carbon import instrumentation
+    state.instrumentation = instrumentation
+
     root_service = CarbonRootService()
     root_service.setName(settings.program)
 


### PR DESCRIPTION
Ported the min_datapoints_per_update feature.
Placed the logic in cache.py in the sorting strategies.
Added a line in config file on LOW_CACHE_SIZE to avoid misconfiguration.
