### PR TITLE
fixed bug with min_datapoints_per_update in max strategy; waived min_…

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -76,8 +76,7 @@ class RandomStrategy(DrainStrategy):
   def choose_item(self, mdpu = 0):
     metric_name =  choice(self.cache.keys())
     if mdpu == 1:
-      count = 0.1 * len(self.cache) 
-      log.msg("Cache Queues: {0}".format(len(self.cache)))
+      count = 0.1 * len(self.cache)       
       while count > 0: 
         try:
           dbFilePath = getFilesystemPath(metric_name)

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -73,9 +73,12 @@ def optimalWriteOrder():
       break; 
     if state.cacheTooFull and MetricCache.size < CACHE_SIZE_LOW_WATERMARK:
       events.cacheSpaceAvailable()
-
-    dbFilePath = getFilesystemPath(metric)
-    dbFileExists = exists(dbFilePath)
+    try:
+      dbFilePath = getFilesystemPath(metric)
+      dbFileExists = exists(dbFilePath)
+    except Exception:
+      log.msg("Invalid metric_name {0}".format(metric)) 
+      continue
 
     if not dbFileExists and CREATE_BUCKET:
       # If our tokenbucket has enough tokens available to create a new metric


### PR DESCRIPTION
…datapoints_per_update for new metrics; Added exception handling for calls to os.path.exists
A change in min_datapoints_per_update for random cache strategy: return None only when all of a 'certain number' of randomly selected metrics have less than 'min_datapoints_per_update' datapoints; this 'certain number' is set to one-tenth of total number of metrics in cache. This is to avoid sleep of writer thread when the randomly selected metric has less datapoints in cache but there are other metrics in cache which have greater number of datapoints than the threshold. 
